### PR TITLE
Fix size_t to DWORD cast warnings

### DIFF
--- a/LaunchAppContainer/LaunchAppContainer/LaunchAppContainer.cpp
+++ b/LaunchAppContainer/LaunchAppContainer/LaunchAppContainer.cpp
@@ -148,7 +148,7 @@ DWORD CreateAppContainerProfileWithMoniker(PSID* pAppContainerSid)
                                            pDisplayString, 
                                            pDisplayString, 
                                            CapabilityList.data(), 
-                                           CapabilityList.size(), 
+                                           static_cast<DWORD>(CapabilityList.size()), 
                                            &PackageSid);
     if (FAILED(hr))
     {
@@ -235,7 +235,7 @@ DWORD LaunchProcess(PSID PackageSid)
     }
 
     // Setup the app container capabilities attribute.
-    SecurityCapabilities.CapabilityCount = CapabilityList.size();
+    SecurityCapabilities.CapabilityCount = static_cast<DWORD>(CapabilityList.size());
     SecurityCapabilities.Capabilities = CapabilityList.data();
     SecurityCapabilities.AppContainerSid = PackageSid;
     SecurityCapabilities.Reserved = 0;


### PR DESCRIPTION
Fix the following warnings:
```
LaunchAppContainer\LaunchAppContainer\LaunchAppContainer.cpp(152,55): warning C4267: 'argument': conversion from 'size_t' to 'DWORD', possible loss of data
LaunchAppContainer\LaunchAppContainer\LaunchAppContainer.cpp(238,65): warning C4267: '=': conversion from 'size_t' to 'DWORD', possible loss of data
```

Thanks a lot for sharing the `LaunchAppContainer` sources! It's very useful to have an official reference implementation on AppContainer isolation from Microsoft.