### PR TITLE
Fix broken README.md reference

### DIFF
--- a/LaunchAppContainer/LaunchAppContainer.sln
+++ b/LaunchAppContainer/LaunchAppContainer.sln
@@ -5,6 +5,11 @@ VisualStudioVersion = 17.3.32929.385
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "LaunchAppContainer", "LaunchAppContainer\LaunchAppContainer.vcxproj", "{6909E635-E570-4A64-9318-8C4A9C5FFA47}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{71AF855D-5864-4E50-A0ED-4FD3F07D7C19}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64

--- a/LaunchAppContainer/LaunchAppContainer/LaunchAppContainer.vcxproj
+++ b/LaunchAppContainer/LaunchAppContainer/LaunchAppContainer.vcxproj
@@ -134,9 +134,6 @@
   <ItemGroup>
     <ClCompile Include="LaunchAppContainer.cpp" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="README.md" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/LaunchAppContainer/LaunchAppContainer/LaunchAppContainer.vcxproj.filters
+++ b/LaunchAppContainer/LaunchAppContainer/LaunchAppContainer.vcxproj.filters
@@ -19,7 +19,4 @@
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="README.md" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
The LaunchAppContainer project contained a broken referred to README.md. Remove broken reference. Instead add the README.md reference to the solution instead of the project, since the file is located _outside_ the project folder.